### PR TITLE
The number 0 in left, in month or in day, don't works.

### DIFF
--- a/js/bic_calendar.js
+++ b/js/bic_calendar.js
@@ -189,7 +189,15 @@ $.fn.bic_calendar = function(options) {
             var ultimoDiaMes = ultimoDia(mes,ano);
             
             var n_mes = mes + 1;
+
+            if (n_mes.toString().length == 1) {
+                n_mes = "0"+n_mes;
+            }            
             
+            if (contadorDias.toString().length == 1) {
+                contadorDias = "0"+contadorDias;
+            }
+
             var capaDiasMes_string = "";
 			
             //escribo la primera fila de la semana


### PR DESCRIPTION
Add support to DD and MM formats. Today only date like 6/6/2013 is accepted, but 06/06/2013 not. The number 0 in left, causes the problem.
